### PR TITLE
Add JSONDecoder Extension to Eecode from Dictionary.

### DIFF
--- a/Sources/Swixtensions/Extensions/JSONDecoder+.swift
+++ b/Sources/Swixtensions/Extensions/JSONDecoder+.swift
@@ -1,0 +1,16 @@
+//
+//  JSONDecoder+.swift
+//  
+//
+//  Created by Branden Smith on 10/6/20.
+//
+
+import Foundation
+
+public extension JSONDecoder {
+    func decode<T: Decodable>(_ type: T.Type, from dictionary: [String: Any]) throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [.fragmentsAllowed])
+
+        return try self.decode(type, from: data)
+    }
+}

--- a/Tests/SwixtensionsTests/JSONDecoderTests.swift
+++ b/Tests/SwixtensionsTests/JSONDecoderTests.swift
@@ -1,0 +1,31 @@
+//
+//  JSONDecoderTests.swift
+//  
+//
+//  Created by Branden Smith on 10/6/20.
+//
+
+import XCTest
+@testable import Swixtensions
+
+struct Person: Codable, Equatable {
+    let name: String
+    let age: Int
+}
+
+final class JSONDecoderTests: XCTestCase {
+    func testDecodeFromDictionary() {
+        let personDict: [String: Any] = [
+            "name": "Steve",
+            "age": 50
+        ]
+
+        let decoded: Person = try! JSONDecoder().decode(Person.self, from: personDict)
+
+        XCTAssert(decoded == Person(name: "Steve", age: 50))
+    }
+
+    static var allTests = [
+        ("testDecodeFromDictionary", testDecodeFromDictionary)
+    ]
+}


### PR DESCRIPTION
# Summary

This change adds an extension on JSONDecoder to allow decoding from a `Dictionary<String, Any>`