### PR TITLE
Add Extension to make CLLocationCoordinate2D Codable.

### DIFF
--- a/Sources/Swixtensions/Extensions/CLLocationCoordinate2D+Codable.swift
+++ b/Sources/Swixtensions/Extensions/CLLocationCoordinate2D+Codable.swift
@@ -1,0 +1,32 @@
+//
+//  CLLocationCoordinate2D+Codable.swift
+//  
+//
+//  Created by Branden Smith on 2/12/21.
+//
+
+import Foundation
+import CoreLocation
+
+extension CLLocationCoordinate2D: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case latitude
+        case longitude
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.init()
+
+        self.latitude = try container.decode(Double.self, forKey: .latitude)
+        self.longitude = try container.decode(Double.self, forKey: .longitude)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(latitude, forKey: .latitude)
+        try container.encode(longitude, forKey: .longitude)
+    }
+}


### PR DESCRIPTION
# Summary

This change adds an extension to make `CLLocationCoordinate2D` Codable. 