### PR TITLE
Bugfix/Fix Argument for Date Decoding Strategy.

### DIFF
--- a/Sources/Swixtensions/Extensions/UserDefaults+.swift
+++ b/Sources/Swixtensions/Extensions/UserDefaults+.swift
@@ -14,7 +14,7 @@ public extension UserDefaults {
 }
 
 public extension UserDefaults {
-    func decodedValue<T: Codable>(forKey key: String, dateDecodingStrategy: JSONDecoder.DataDecodingStrategy? = nil) -> T? {
+    func decodedValue<T: Codable>(forKey key: String, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy? = nil) -> T? {
         var value: Data
 
         #if DEBUG

--- a/Sources/Swixtensions/Extensions/UserDefaults+.swift
+++ b/Sources/Swixtensions/Extensions/UserDefaults+.swift
@@ -52,7 +52,10 @@ public extension UserDefaults {
 
     func set<T: Codable>(_ value: T, forKey key: String) throws {
         do {
-            let encoded = try JSONEncoder().encode(value)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+
+            let encoded = try encoder.encode(value)
 
             self.setValue(encoded, forKey: key)
         } catch {

--- a/Sources/Swixtensions/Extensions/UserDefaults+.swift
+++ b/Sources/Swixtensions/Extensions/UserDefaults+.swift
@@ -40,7 +40,7 @@ public extension UserDefaults {
         let decoder = JSONDecoder()
 
         if let dateDecodingStrategy = dateDecodingStrategy {
-            decoder.dataDecodingStrategy = dateDecodingStrategy
+            decoder.dateDecodingStrategy = dateDecodingStrategy
         } else {
             decoder.dateDecodingStrategy = .deferredToDate
         }

--- a/Sources/Swixtensions/Extensions/UserDefaults+.swift
+++ b/Sources/Swixtensions/Extensions/UserDefaults+.swift
@@ -14,7 +14,7 @@ public extension UserDefaults {
 }
 
 public extension UserDefaults {
-    func decodedValue<T: Codable>(forKey key: String, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy? = nil) -> T? {
+    func decodedValue<T: Codable>(forKey key: String, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy? = .iso8601) -> T? {
         var value: Data
 
         #if DEBUG


### PR DESCRIPTION
# Summary

This change fixes the Date decoding strategy argument to be the Date decoding strategy rather than the data decoding strategy. It also defaults to ISO8601 for the default date encoding and decoding. 